### PR TITLE
Add MMC support to sheevaplug

### DIFF
--- a/board/Marvell/sheevaplug/sheevaplug.c
+++ b/board/Marvell/sheevaplug/sheevaplug.c
@@ -13,6 +13,10 @@
 #include <asm/arch/mpp.h>
 #include "sheevaplug.h"
 
+#ifdef CONFIG_KIRKWOOD_MMC
+#include <kirkwood_mmc.h>
+#endif /* CONFIG_KIRKWOOD_MMC */
+
 DECLARE_GLOBAL_DATA_PTR;
 
 int board_early_init_f(void)
@@ -131,3 +135,12 @@ void reset_phy(void)
 	printf("88E1116 Initialized on %s\n", name);
 }
 #endif /* CONFIG_RESET_PHY_R */
+
+#ifdef CONFIG_KIRKWOOD_MMC
+int board_mmc_init(bd_t *bis)
+{
+       kw_mmc_initialize(bis);
+       return 0;
+}
+#endif /* CONFIG_KIRKWOOD_MMC */
+

--- a/include/configs/sheevaplug.h
+++ b/include/configs/sheevaplug.h
@@ -29,14 +29,18 @@
  * Commands configuration
  */
 #define CONFIG_SYS_NO_FLASH		/* Declare no flash (NOR/SPI) */
+#define CONFIG_SYS_MVFS
 #define CONFIG_CMD_DHCP
 #define CONFIG_CMD_ENV
 #define CONFIG_CMD_MII
+#define CONFIG_CMD_MMC
 #define CONFIG_CMD_NAND
 #define CONFIG_CMD_PING
 #define CONFIG_CMD_USB
 #define CONFIG_CMD_DATE
 #define CONFIG_SYS_LONGHELP
+#define CONFIG_AUTO_COMPLETE
+#define CONFIG_CMDLINE_EDITING
 #define CONFIG_PREBOOT
 #define CONFIG_SYS_HUSH_PARSER
 #define CONFIG_SYS_PROMPT_HUSH_PS2 "> "


### PR DESCRIPTION
This makes the sheevaplug u-boot more consistent with other Kirkwood platforms that have an SD card slot by enabling the mmc command and allowing boot from SD.